### PR TITLE
Fixed ft_strtrim() test not making a difference between an empty string and NULL

### DIFF
--- a/templates/libft/ft_strtrim.c
+++ b/templates/libft/ft_strtrim.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_strtrim.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tdameros <tdameros@student.42lyon.fr>      +#+  +:+       +#+        */
+/*   By: vfries <vfries@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/08 23:55:03 by tdameros          #+#    #+#             */
-/*   Updated: 2022/10/08 23:56:39 by tdameros         ###   ########lyon.fr   */
+/*   Updated: 2022/10/12 01:23:15 by vfries           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,11 @@ int	main(int argc, char **argv)
 		if (s != NULL)
 		{
 			printf("%s", s);
+			if (*s == '\0')
+				printf("\"\"");
 			free(s);
 		}
+		else
+			printf("NULL");
 	}
 }

--- a/tests/libft.py
+++ b/tests/libft.py
@@ -481,13 +481,13 @@ def ft_strjoin(path):
 def ft_strtrim(path):
     tests = [
         {"args": ["  test  ", " "], "expected": "test"},
-        {"args": ["         ", " "], "expected": ""},
+        {"args": ["         ", " "], "expected": "\"\""},
         {"args": ["  marvin bot   ", " "], "expected": "marvin bot"},
         {"args": [" z42 networkzzz z z ", " z"], "expected": "42 network"},
         {"args": ["abcdeeedbcatabcddecb", "abcde"], "expected": "t"},
         {"args": ["42", ""], "expected": "42"},
         {"args": ["hello world", " lw"], "expected": "hello world"},
-        {"args": ["", ""], "expected": ""},
+        {"args": ["", ""], "expected": "\"\""},
     ]
     return test_exercise(path, "ft_strtrim.c", "libft.a", tests)
 


### PR DESCRIPTION
When `ft_strtrim()` returned `NULL` the test wouldn't print anything.
When `ft_strtrim()` would return an empty string, `printf()` would print that string but since it is empty the output would be empty.

Because of that the test couldn't tell if `NULL` or an empty string was returned