### PR TITLE
Fixed traceback error

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,9 +71,9 @@ if __name__ == "__main__":
     GOINFRE_PATH = get_goinfre_dir()
     PATH = GOINFRE_PATH / "ft_iig"
     print('\n' + '\n'.join([f"* - {project}" for project in PROJECTS.keys()]) + '\n')
-    select_project = input("Select your project (name) :")
-    while select_project.upper() not in PROJECTS:
-        select_project = input("[INVALID] Select your project (name) :")
+    select_project = input("Select your project (name) :").upper()
+    while select_project not in PROJECTS:
+        select_project = input("[INVALID] Select your project (name) :").upper()
     run_git_clone()
     run_norminette()
     PROJECTS.get(select_project)(PATH)


### PR DESCRIPTION
Entering "libft" when asked for a project would lead to the following traceback error:

> Traceback (most recent call last):
> > File "PATH_TO_FT-IIG/main.py", line 79, in \<module\>
> > > PROJECTS.get(select_project)(PATH)
>
> TypeError: 'NoneType' object is not callable