### PR TITLE
Added a test to ft_putnbr_fd()

### DIFF
--- a/tests/libft.py
+++ b/tests/libft.py
@@ -636,6 +636,7 @@ def ft_putnbr_fd(path):
         {"args": ["+2147483647", 1], "expected": "2147483647"},
         {"args": ["-2147483648", 1], "expected": "-2147483648"},
         {"args": ["-2147483647", 1], "expected": "-2147483647"},
+        {"args": ["0", 1], "expected": "0"},
 
     ]
     return test_exercise(path, "ft_putnbr_fd.c", "libft.a", tests)


### PR DESCRIPTION
Some recursive solutions to `ft_putnbr_fd()` could pass all the tests but not work with 0 as input

```c
void	ft_putnbr_fd(int n, int fd)
{
	long	long_n;
	char	c;

	long_n = n;
	if (long_n < 0)
	{
		write(fd, "-", 1);
		long_n = -long_n;
	}
	if (n == 0)
		return ;
	ft_putnbr_fd(long_n / 10, fd);
	c = long_n % 10 + '0';
	write(fd, &c, 1);
}
```