### PR TITLE
Added distinction between compilation errors and absent make rules

### DIFF
--- a/tests/libft.py
+++ b/tests/libft.py
@@ -29,8 +29,11 @@ def bonus_tests(path):
     rows = [["Test", "Your Result", "Expected Result", "Status"]]
     if not make("fclean", path):
         return print_warning("Fclean rule not found, can not test bonus.")
-    if not make("bonus", path):
-        return print_warning("Bonus rule not found")
+    make_return = make("bonus", path)
+    if make_return == 2:
+        return print_warning("bonus rule not found")
+    if make_return == 0:
+        return print_warning("Bonus does not compile!")
     for function in test_functions:
         test_results = function(path)
         test_results_ko = remove_ok_tests(test_results)
@@ -58,8 +61,11 @@ def mandatory_tests(path):
     rows = [["Test", "Your Result", "Expected Result", "Status"]]
     print_info("Compiling libft.a with your makefile (re rule).")
     print_info("Running tests...")
-    if not make("re", path):
-        return print_warning("libft.a does not compile !")
+    make_return = make("re", path)
+    if make_return == 2:
+        return print_warning("re rule not found")
+    if make_return == 0:
+        return print_warning("libft.a does not compile!")
     for function in test_functions:
         test_results = function(path)
         test_results_ko = remove_ok_tests(test_results)

--- a/utils/compilation.py
+++ b/utils/compilation.py
@@ -20,9 +20,10 @@ def compile(out_name, *files):
 
 def make(rule, path):
     logging.debug(f"make {rule} ({str(path)})")
-    make = subprocess.Popen(["make", rule], cwd=path, stdout=subprocess.PIPE,
+    make = subprocess.run(["make", rule], cwd=path, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-    make.wait()
+    if "No rule to make target" in make.stderr.decode():
+        return 2
     if make.returncode != 0:
         return 0
     return 1


### PR DESCRIPTION
Currently when there is an error with the makefile, no matter what the reason, "Bonus rule not found" is printed for the bonus rule and "libft.a does not compile !" is printed for the re rule.

With my changes, if the re rule doesn't compile "libft.a does not compile!" will be printed, if it doesn't exist "re rule not found" will be printed. If the bonus rule doesn't compile "Bonus does not compile!" will be printed, if it doesn't exist "bonus rule not found" will be printed.